### PR TITLE
Adding MAX_REQUESTS environment variable to private service spec

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       - CB_PASSPHRASE
       - CB_REST_URL=https://api-public.sandbox.pro.coinbase.com
       - REQUEST_SUFFIX=accounts
+      - MAX_REQUESTS=5
     command:
       - python
       - /app/private.py


### PR DESCRIPTION
One-liner here. This fixed the private service for me, but not sure if I messed something up to lose the MAX_REQUESTS env var.